### PR TITLE
FIX: use localhost if DOCKER_HOST not defined

### DIFF
--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -7,6 +7,7 @@ if env | egrep -q "DOCKER_RIAK_CS_DEBUG"; then
 fi
 
 CLEAN_DOCKER_HOST=$(echo "${DOCKER_HOST}" | cut -d'/' -f3 | cut -d':' -f1)
+CLEAN_DOCKER_HOST=${CLEAN_DOCKER_HOST:-localhost}
 DOCKER_RIAK_CS_CLUSTER_SIZE=${DOCKER_RIAK_CS_CLUSTER_SIZE:-5}
 
 if docker ps -a | egrep "hectcastro/riak" >/dev/null; then


### PR DESCRIPTION
DOCKER_HOST is only needed if we are using boot2docker otherwise we can use localhost as before eb68b685
