### PR TITLE
Fix creds extraction when 1 use only one node

### DIFF
--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -114,6 +114,11 @@ if [ -f $INSECURE_KEY_FILE ]; then
   echo "  Riak CS credentials:"
   echo
 
+  # If starting only one node we need to wait a litle bit for keys
+  if [ ${DOCKER_RIAK_CS_CLUSTER_SIZE} -eq 1 ] ; then
+      sleep 30
+  fi
+
   for field in admin_key admin_secret ; do
     echo -n "    ${field}: "
 


### PR DESCRIPTION
Hi,

When I start a cluster with only one node (DOCKER_RIAK_CS_CLUSTER_SIZE=1) the credentials printed are not correct. This is just a fix to wait some time in that case. It also could be done using *pooling* until *admin_key* change from *admin-key*, what do you think?