### PR TITLE
Update start-cluster.sh

### DIFF
--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -53,7 +53,7 @@ do
                -P --name "riak-cs${index}" -d hectcastro/riak-cs > /dev/null 2>&1
   fi
 
-  CONTAINER_ID=$(docker ps | egrep "riak-cs${index}[^/]" | cut -d" " -f1)
+  CONTAINER_ID=$(docker ps | egrep "riak-cs${index}" | cut -d" " -f1)
   CONTAINER_PORT=$(docker port "${CONTAINER_ID}" 8080 | cut -d ":" -f2)
 
   until curl -s "http://${CLEAN_DOCKER_HOST}:${CONTAINER_PORT}/riak-cs/ping" | egrep "OK" > /dev/null 2>&1;


### PR DESCRIPTION
egrep looks for a character which is not slash. This doesn't work at an end of line.

in my case without the patch it resulted in an empty CONTAINER_ID and an error in the following line.